### PR TITLE
Fix issue with computed ranges for one-hot encoded features

### DIFF
--- a/apt/minimization/minimizer.py
+++ b/apt/minimization/minimizer.py
@@ -576,7 +576,7 @@ class GeneralizeToRepresentative(BaseEstimator, MetaEstimatorMixin, TransformerM
             if feature not in feature_data.keys():
                 fd = {}
                 values = list(x.loc[:, feature])
-                if feature not in self.categorical_features:
+                if feature not in self.categorical_features and feature not in self.all_one_hot_features:
                     fd['min'] = min(values)
                     fd['max'] = max(values)
                     fd['range'] = max(values) - min(values)


### PR DESCRIPTION
1-hot encoded feature ranges were computed like a numeric value instead of a categorical value. This would in some corner cases lead to a division by zero exception due to the range being 0. This was fixed to be computed correctly. Added a test to cover this case.